### PR TITLE
curl：adds custom configuration items  && proxy add type

### DIFF
--- a/src/ConfigurationDefaults.php
+++ b/src/ConfigurationDefaults.php
@@ -46,6 +46,7 @@ class ConfigurationDefaults
     public const PROXY_CONFIGURATION = [
         'port' => 0,
         'tunnel' => false,
+        'type' => CURLPROXY_HTTP,
         'address' => '',
         'auth' => ['user' => '', 'pass' => '', 'method' => CURLAUTH_BASIC]
     ];

--- a/src/PaypalServerSdkClient.php
+++ b/src/PaypalServerSdkClient.php
@@ -63,7 +63,7 @@ class PaypalServerSdkClient implements ConfigurationInterface
         }
         $this->proxyConfiguration = $this->config['proxyConfiguration'] ?? ConfigurationDefaults::PROXY_CONFIGURATION;
         $this->client = ClientBuilder::init(
-            new HttpClient(Configuration::init($this)->proxyConfiguration($this->proxyConfiguration))
+            new HttpClient(Configuration::init($this)->curlOpts($this->config['curlOpts'])->proxyConfiguration($this->proxyConfiguration))
         )
             ->converter(new CompatibilityConverter())
             ->jsonHelper(ApiHelper::getJsonHelper())

--- a/src/PaypalServerSdkClientBuilder.php
+++ b/src/PaypalServerSdkClientBuilder.php
@@ -138,6 +138,29 @@ class PaypalServerSdkClientBuilder
         return $this;
     }
 
+    /**
+     * custom curl opts
+     * like:PaypalServerSdkClientBuilder::init()
+     *   ->environment($this->environment)
+     *   ->curlOpts([CURLOPT_COOKIE, 'foo=bar'])
+     * @param array $curlOpts
+     * @return $this
+     * @author Terry
+     */
+    public function curlOpts(array $curlOpts): self
+    {
+        $this->config['curlOpts'] = $curlOpts;
+
+        return $this;
+    }
+    
+    public function curlOpts(array $curlOpts): self
+    {
+        $this->config['curlOpts'] = $curlOpts;
+
+        return $this;
+    }
+
     public function build(): PaypalServerSdkClient
     {
         return new PaypalServerSdkClient($this->config);

--- a/src/PaypalServerSdkClientBuilder.php
+++ b/src/PaypalServerSdkClientBuilder.php
@@ -153,13 +153,6 @@ class PaypalServerSdkClientBuilder
 
         return $this;
     }
-    
-    public function curlOpts(array $curlOpts): self
-    {
-        $this->config['curlOpts'] = $curlOpts;
-
-        return $this;
-    }
 
     public function build(): PaypalServerSdkClient
     {

--- a/src/Proxy/ProxyConfigurationBuilder.php
+++ b/src/Proxy/ProxyConfigurationBuilder.php
@@ -12,6 +12,8 @@ class ProxyConfigurationBuilder
 
     private $port = ConfigurationDefaults::PROXY_CONFIGURATION['port'];
 
+    private $type = ConfigurationDefaults::PROXY_CONFIGURATION['type'];
+
     private $user = ConfigurationDefaults::PROXY_CONFIGURATION['auth']['user'];
 
     private $pass = ConfigurationDefaults::PROXY_CONFIGURATION['auth']['pass'];
@@ -61,6 +63,15 @@ class ProxyConfigurationBuilder
     }
 
     /**
+     * Set the proxy port
+     */
+    public function type(int $type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
      * Set proxy authentication method
      */
     public function authMethod(string $authMethod): self
@@ -83,6 +94,7 @@ class ProxyConfigurationBuilder
     {
         return [
             'port' => $this->port,
+            'type' => $this->type,
             'tunnel' => $this->tunnel,
             'address' => $this->address,
             'auth' => ['user' => '$this->user', 'pass' => '$this->pass', 'method' => $this->authMethod]

--- a/src/Proxy/ProxyConfigurationBuilder.php
+++ b/src/Proxy/ProxyConfigurationBuilder.php
@@ -97,7 +97,7 @@ class ProxyConfigurationBuilder
             'type' => $this->type,
             'tunnel' => $this->tunnel,
             'address' => $this->address,
-            'auth' => ['user' => '$this->user', 'pass' => '$this->pass', 'method' => $this->authMethod]
+            'auth' => ['user' => "$this->user", 'pass' => "$this->pass", 'method' => $this->authMethod]
         ];
     }
 }


### PR DESCRIPTION
1.use curlOpts ：adds custom configuration items

use：

protected function getClient()
    {

        return PaypalServerSdkClientBuilder::init()
            ->clientCredentialsAuthCredentials(
                ClientCredentialsAuthCredentialsBuilder::init(
                    $this->clientId,
                    $this->clientSecret
                )
            )
            ->environment($this->environment)
            ->curlOpts([CURLOPT_COOKIE => 'foo=bar'])
            ->build();
    }

2.proxy add  type， like：CURLPROXY_HTTP，CURLPROXY_SOCKS4