### PR TITLE
pass PayPal-Partner-Attribution-Id header with get/capture order calls

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -94,6 +94,7 @@ class OrdersController extends BaseController
                 TemplateParam::init('id', $options)->extract('id'),
                 HeaderParam::init('PayPal-Mock-Response', $options)->extract('paypalMockResponse'),
                 HeaderParam::init('PayPal-Auth-Assertion', $options)->extract('paypalAuthAssertion'),
+                HeaderParam::init('PayPal-Partner-Attribution-Id', $options)->extract('paypalPartnerAttributionId'),
                 QueryParam::init('fields', $options)->extract('fields')
             );
 
@@ -341,6 +342,7 @@ class OrdersController extends BaseController
                 HeaderParam::init('Prefer', $options)->extract('prefer', 'return=minimal'),
                 HeaderParam::init('PayPal-Client-Metadata-Id', $options)->extract('paypalClientMetadataId'),
                 HeaderParam::init('PayPal-Auth-Assertion', $options)->extract('paypalAuthAssertion'),
+                HeaderParam::init('PayPal-Partner-Attribution-Id', $options)->extract('paypalPartnerAttributionId'),
                 BodyParam::init($options)->extract('body')
             );
 


### PR DESCRIPTION
When working on PPCP integration, we have been told we need to pass Partner ID header for get/capture order calls.

This change enables this (in the same way it currently works with create order calls).

The developer docs would need updating to show the availability of this parameter.